### PR TITLE
148-ändra-lösenord

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -55,7 +55,11 @@ namespace PegasusBackend.Controllers
         public async Task<ActionResult<bool?>> DevLogin(LoginRequestDto request) =>
             Generate.ActionResult<bool?>(await authService.DevLoginAsync(request, HttpContext));
 
-
+        [HttpPut("ChangePassword")]
+        [Authorize]
+        [EnableRateLimiting("AuthPolicy")] 
+        public async Task<ActionResult<bool>> ChangePassword([FromBody] ChangePasswordDto request) =>
+            Generate.ActionResult(await passwordResetService.ChangePasswordAsync(request, HttpContext));
 
         [HttpPost("ForgotPassword")]
         [EnableRateLimiting("PasswordResetPolicy")]

--- a/DTOs/AuthDTOs/ChangePasswordDto.cs
+++ b/DTOs/AuthDTOs/ChangePasswordDto.cs
@@ -1,0 +1,9 @@
+﻿namespace PegasusBackend.DTOs.AuthDTOs
+{
+    public class ChangePasswordDto
+    {
+        public string CurrentPassword { get; set; } = string.Empty;
+        public string NewPassword { get; set; } = string.Empty;
+        public string ConfirmNewPassword { get; set; } = string.Empty;
+    }
+}

--- a/Services/Implementations/PasswordResetService.cs
+++ b/Services/Implementations/PasswordResetService.cs
@@ -257,18 +257,6 @@ namespace PegasusBackend.Services.Implementations
                     );
                 }
 
-                // Check if account is locked
-                if (await _userManager.IsLockedOutAsync(user))
-                {
-                    _logger.LogWarning(
-                        "Locked out user {Email} attempted to change password",
-                        user.Email
-                    );
-                    return ServiceResponse<bool>.FailResponse(
-                        HttpStatusCode.Forbidden,
-                        "Your account is locked. Please contact support."
-                    );
-                }
 
                 // Verify current password
                 var isCurrentPasswordValid = await _userManager.CheckPasswordAsync(user, request.CurrentPassword);

--- a/Services/Implementations/PasswordResetService.cs
+++ b/Services/Implementations/PasswordResetService.cs
@@ -2,17 +2,21 @@
 using Microsoft.Extensions.Options;
 using PegasusBackend.Configurations;
 using PegasusBackend.DTOs.AuthDTOs;
+using PegasusBackend.Helpers.JwtCookieOptions;
 using PegasusBackend.Helpers.MailjetHelpers;
 using PegasusBackend.Models;
+using PegasusBackend.Repositorys.Interfaces;
 using PegasusBackend.Responses;
 using PegasusBackend.Services.Interfaces;
 using System.Net;
+
 
 namespace PegasusBackend.Services.Implementations
 {
     public class PasswordResetService : IPasswordResetService
     {
         private readonly UserManager<User> _userManager;
+        private readonly IUserRepo _userRepo;
         private readonly IMailjetEmailService _mailjetEmailService;
         private readonly IUserService _userService;
         private readonly ILogger<PasswordResetService> _logger;
@@ -21,11 +25,13 @@ namespace PegasusBackend.Services.Implementations
         public PasswordResetService(
             UserManager<User> userManager,
             IMailjetEmailService mailjetEmailService,
+            IUserRepo userRepo,
             IUserService userService,
             ILogger<PasswordResetService> logger,
             IOptions<PasswordResetSettings> passwordResetSettings)
         {
             _userManager = userManager;
+            _userRepo = userRepo;
             _mailjetEmailService = mailjetEmailService;
             _userService = userService;
             _logger = logger;
@@ -204,6 +210,121 @@ namespace PegasusBackend.Services.Implementations
             {
                 _logger.LogError(ex, "Unexpected error resetting password for {Email}", request.Email);
 
+                return ServiceResponse<bool>.FailResponse(
+                    HttpStatusCode.InternalServerError,
+                    "An unexpected error occurred. Please try again or contact support."
+                );
+            }
+        }
+
+        public async Task<ServiceResponse<bool>> ChangePasswordAsync(ChangePasswordDto request, HttpContext httpContext)
+        {
+            try
+            {
+                var user = await _userManager.GetUserAsync(httpContext.User);
+
+                if (user == null)
+                {
+                    return ServiceResponse<bool>.FailResponse(
+                        HttpStatusCode.Unauthorized,
+                        "You must be logged in to change your password."
+                    );
+                }
+
+                // Check if user is soft-deleted
+                if (user.IsDeleted)
+                {
+                    _logger.LogWarning(
+                        "Deleted user {Email} attempted to change password",
+                        user.Email
+                    );
+                    return ServiceResponse<bool>.FailResponse(
+                        HttpStatusCode.Forbidden,
+                        "This account has been deleted."
+                    );
+                }
+
+                // Check if email is confirmed
+                if (!user.EmailConfirmed)
+                {
+                    _logger.LogWarning(
+                        "Unconfirmed user {Email} attempted to change password",
+                        user.Email
+                    );
+                    return ServiceResponse<bool>.FailResponse(
+                        HttpStatusCode.Forbidden,
+                        "You must confirm your email before changing your password."
+                    );
+                }
+
+                // Check if account is locked
+                if (await _userManager.IsLockedOutAsync(user))
+                {
+                    _logger.LogWarning(
+                        "Locked out user {Email} attempted to change password",
+                        user.Email
+                    );
+                    return ServiceResponse<bool>.FailResponse(
+                        HttpStatusCode.Forbidden,
+                        "Your account is locked. Please contact support."
+                    );
+                }
+
+                // Verify current password
+                var isCurrentPasswordValid = await _userManager.CheckPasswordAsync(user, request.CurrentPassword);
+                if (!isCurrentPasswordValid)
+                {
+                    _logger.LogWarning(
+                        "User {Email} provided incorrect current password",
+                        user.Email
+                    );
+                    return ServiceResponse<bool>.FailResponse(
+                        HttpStatusCode.BadRequest,
+                        "Current password is incorrect."
+                    );
+                }
+
+                // Change password - this automatically updates SecurityStamp
+                var result = await _userManager.ChangePasswordAsync(
+                    user,
+                    request.CurrentPassword,
+                    request.NewPassword
+                );
+
+                if (!result.Succeeded)
+                {
+                    var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+                    _logger.LogWarning(
+                        "Failed to change password for user {Email}: {Errors}",
+                        user.Email,
+                        errors
+                    );
+                    return ServiceResponse<bool>.FailResponse(
+                        HttpStatusCode.BadRequest,
+                        $"Password does not meet requirements: {errors}"
+                    );
+                }
+
+                // Invalidate refresh token using existing helper for consistency
+                await _userRepo.HandleRefreshToken(user, null);
+
+                // Clear authentication cookies to force re-login
+                HandleAuthenticationCookies.ClearAuthenticationCookies(httpContext);
+
+                _logger.LogInformation(
+                    "Password changed successfully for user {Email}. Session invalidated.",
+                    user.Email
+                );
+
+                return ServiceResponse<bool>.SuccessResponse(
+                    HttpStatusCode.OK,
+                    true,
+                    "Your password has been changed successfully. Please log in with your new password."
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error changing password");
                 return ServiceResponse<bool>.FailResponse(
                     HttpStatusCode.InternalServerError,
                     "An unexpected error occurred. Please try again or contact support."

--- a/Services/Interfaces/IPasswordResetService.cs
+++ b/Services/Interfaces/IPasswordResetService.cs
@@ -7,5 +7,6 @@ namespace PegasusBackend.Services.Interfaces
     {
         Task<ServiceResponse<bool>> ForgotPasswordAsync(RequestPasswordResetDto request);
         Task<ServiceResponse<bool>> ResetPasswordAsync(ConfirmPasswordResetDto request);
+        Task<ServiceResponse<bool>> ChangePasswordAsync(ChangePasswordDto request, HttpContext httpContext);
     }
 }

--- a/Validators/AuthValidators/ChangePasswordValidator.cs
+++ b/Validators/AuthValidators/ChangePasswordValidator.cs
@@ -1,0 +1,29 @@
+﻿using FluentValidation;
+using PegasusBackend.DTOs.AuthDTOs;
+
+namespace PegasusBackend.Validators.AuthValidators
+{
+    public class ChangePasswordValidator : AbstractValidator<ChangePasswordDto>
+    {
+        public ChangePasswordValidator()
+        {
+            RuleFor(x => x.CurrentPassword)
+                .NotEmpty().WithMessage("Current password is required.")
+                .MinimumLength(6).WithMessage("Current password must be at least 6 characters.");
+
+            RuleFor(x => x.NewPassword)
+                .NotEmpty().WithMessage("New password is required.")
+                .MinimumLength(6).WithMessage("Password must be at least 6 characters.")
+                .MaximumLength(100).WithMessage("Password cannot exceed 100 characters.")
+                .Matches(@"[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
+                .Matches(@"[a-z]").WithMessage("Password must contain at least one lowercase letter.")
+                .Matches(@"[0-9]").WithMessage("Password must contain at least one number.")
+                .Matches(@"[^a-zA-Z0-9]").WithMessage("Password must contain at least one special character.")
+                .NotEqual(x => x.CurrentPassword).WithMessage("New password must be different from current password.");
+
+            RuleFor(x => x.ConfirmNewPassword)
+                .NotEmpty().WithMessage("Password confirmation is required.")
+                .Equal(x => x.NewPassword).WithMessage("The new password and confirmation password do not match.");
+        }
+    }
+}


### PR DESCRIPTION
feat: now allows users that are logged in and confirmed to change their password. They have the same password requirements as the forgotpassword. You must put in the current password and then the new one and then the new one again to confirm. 