### PR TITLE
Add unit tests for IdempotencyService

### DIFF
--- a/PegasusBackend.Tests/Services/BookingServiceTests.cs
+++ b/PegasusBackend.Tests/Services/BookingServiceTests.cs
@@ -1,0 +1,731 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using PegasusBackend.Configurations;
+using PegasusBackend.DTOs.BookingDTOs;
+using PegasusBackend.DTOs.MapDTOs;
+using PegasusBackend.DTOs.ValidationResults;
+using PegasusBackend.Helpers;
+using PegasusBackend.Helpers.BookingHelpers;
+using PegasusBackend.Models;
+using PegasusBackend.Repositorys.Interfaces;
+using PegasusBackend.Responses;
+using PegasusBackend.Services.Implementations.BookingServices;
+using PegasusBackend.Services.Interfaces;
+using PegasusBackend.Services.Interfaces.BookingInterfaces;
+using System.Net;
+
+namespace PegasusBackend.Tests.Services.BookingServices;
+
+public class BookingServiceTests
+{
+    [Fact]
+    public async Task CreateBookingAsync_GuestUser_ReturnsSuccess_WithPendingConfirmation()
+    {
+        // Arrange
+        var mockBookingRepo = new Mock<IBookingRepo>();
+        var mockUserManager = new Mock<UserManager<User>>(
+            new Mock<IUserStore<User>>().Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!
+        );
+        var mockMailjetService = new Mock<IMailjetEmailService>();
+        var mockValidationService = new Mock<IBookingValidationService>();
+        var mockBookingFactory = new Mock<IBookingFactoryService>();
+        var mockBookingMapper = new Mock<IBookingMapperService>();
+        var mockLogger = new Mock<ILogger<BookingService>>();
+        var mockEnv = new Mock<IWebHostEnvironment>();
+        var mockUserService = new Mock<IUserService>();
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var mockMapService = new Mock<IMapService>();
+        var mockDriverRepo = new Mock<IDriverRepo>();
+
+        var mailJetSettings = Options.Create(new MailJetSettings
+        {
+            Links = new MailjetLinks
+            {
+                LocalConfirmationBase = "http://localhost:5000/confirm/",
+                ProductionConfirmationBase = "https://pegasus.se/confirm/",
+                DriverPortalUrl = "https://driver.pegasus.se"
+            }
+        });
+
+        var bookingRulesSettings = Options.Create(new BookingRulesSettings
+        {
+            MinHoursBeforePickupForChange = 2
+        });
+
+        var paginationSettings = Options.Create(new PaginationSettings
+        {
+            DefaultPageSize = 10,
+            MaxPageSize = 100
+        });
+
+        var recalculateHelper = new RecalculateIfAddressChangedHelper(mockValidationService.Object);
+        var validateUpdateRuleHelper = new ValidateUpdateRuleHelper(
+            mockValidationService.Object,
+            bookingRulesSettings.Value
+        );
+
+        var bookingDto = new CreateBookingDto
+        {
+            Email = "guest@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567",
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            PickUpAddress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAddress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            Flightnumber = "SK123"
+        };
+
+        var validationResult = new ValidationResult
+        {
+            IsValid = true,
+            RouteInfo = new RouteInfoDto
+            {
+                DistanceKm = 42.5m,
+                DurationMinutes = 35,
+                Sections = new List<RouteSectionDto>()
+            },
+            CalculatedPrice = 450.00m
+        };
+
+        var booking = new Bookings
+        {
+            BookingId = 1,
+            UserIdFk = null,
+            GuestEmail = "guest@example.com",
+            GuestFirstName = "John",
+            GuestLastName = "Doe",
+            GuestPhoneNumber = "0701234567",
+            Price = 450.00m,
+            BookingDateTime = DateTime.UtcNow,
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            PickUpAdress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAdress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            Status = BookingStatus.PendingEmailConfirmation,
+            ConfirmationToken = "abc123token",
+            IsConfirmed = false,
+            IsAvailable = false,
+            DistanceKm = 42.5m,
+            DurationMinutes = 35
+        };
+
+        var responseDto = new BookingResponseDto
+        {
+            BookingId = 1,
+            Email = "guest@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567",
+            IsGuestBooking = true,
+            Price = 450.00m,
+            Status = BookingStatus.PendingEmailConfirmation,
+            PickUpAddress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAddress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            DistanceKm = 42.5m,
+            DurationMinutes = 35,
+            BookingDateTime = DateTime.UtcNow,
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            IsConfirmed = false
+        };
+
+        mockValidationService
+            .Setup(x => x.ValidateBookingAsync(It.IsAny<CreateBookingDto>()))
+            .ReturnsAsync(validationResult);
+
+        mockUserManager
+            .Setup(x => x.FindByEmailAsync(bookingDto.Email))
+            .ReturnsAsync((User?)null);
+
+        mockBookingFactory
+            .Setup(x => x.CreateBookingEntity(
+                It.IsAny<CreateBookingDto>(),
+                It.IsAny<RouteInfoDto>(),
+                It.IsAny<decimal>(),
+                It.IsAny<User?>(),
+                true))
+            .Returns(booking);
+
+        mockBookingRepo
+            .Setup(x => x.CreateBookingAsync(It.IsAny<Bookings>()))
+            .ReturnsAsync(booking);
+
+        mockMailjetService
+            .Setup(x => x.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<Helpers.MailjetHelpers.MailjetTemplateType>(),
+                It.IsAny<object>(),
+                It.IsAny<string>()))
+            .ReturnsAsync(ServiceResponse<bool>.SuccessResponse(HttpStatusCode.OK, true, "Email sent"));
+
+        mockBookingMapper
+            .Setup(x => x.MapToResponseDTO(It.IsAny<Bookings>()))
+            .Returns(responseDto);
+
+        mockEnv
+            .Setup(x => x.EnvironmentName)
+            .Returns("Development");
+
+        var bookingService = new BookingService(
+            mockBookingRepo.Object,
+            mockUserManager.Object,
+            mockMailjetService.Object,
+            mockValidationService.Object,
+            mockBookingFactory.Object,
+            mockBookingMapper.Object,
+            mockLogger.Object,
+            mailJetSettings,
+            bookingRulesSettings,
+            mockEnv.Object,
+            mockUserService.Object,
+            mockHttpContextAccessor.Object,
+            paginationSettings,
+            recalculateHelper,
+            validateUpdateRuleHelper,
+            mockMapService.Object,
+            mockDriverRepo.Object
+        );
+
+        // Act
+        var result = await bookingService.CreateBookingAsync(bookingDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.NotNull(result.Data);
+        Assert.True(result.Data.IsGuestBooking);
+        Assert.Equal(BookingStatus.PendingEmailConfirmation, result.Data.Status);
+        Assert.Contains("confirm via email", result.Message);
+
+        mockValidationService.Verify(
+            x => x.ValidateBookingAsync(bookingDto),
+            Times.Once());
+
+        mockUserManager.Verify(
+            x => x.FindByEmailAsync(bookingDto.Email),
+            Times.Once());
+
+        mockBookingRepo.Verify(
+            x => x.CreateBookingAsync(It.IsAny<Bookings>()),
+            Times.Once());
+
+        mockMailjetService.Verify(
+            x => x.SendEmailAsync(
+                bookingDto.Email,
+                It.IsAny<Helpers.MailjetHelpers.MailjetTemplateType>(),
+                It.IsAny<object>(),
+                It.IsAny<string>()),
+            Times.Once());
+
+        mockDriverRepo.Verify(
+            x => x.GetAllDriversAsync(),
+            Times.Never());
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_RegisteredUser_ReturnsSuccess_AndNotifiesDrivers()
+    {
+        // Arrange
+        var mockBookingRepo = new Mock<IBookingRepo>();
+        var mockUserManager = new Mock<UserManager<User>>(
+            new Mock<IUserStore<User>>().Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!
+        );
+        var mockMailjetService = new Mock<IMailjetEmailService>();
+        var mockValidationService = new Mock<IBookingValidationService>();
+        var mockBookingFactory = new Mock<IBookingFactoryService>();
+        var mockBookingMapper = new Mock<IBookingMapperService>();
+        var mockLogger = new Mock<ILogger<BookingService>>();
+        var mockEnv = new Mock<IWebHostEnvironment>();
+        var mockUserService = new Mock<IUserService>();
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var mockMapService = new Mock<IMapService>();
+        var mockDriverRepo = new Mock<IDriverRepo>();
+
+        var mailJetSettings = Options.Create(new MailJetSettings
+        {
+            Links = new MailjetLinks
+            {
+                LocalConfirmationBase = "http://localhost:5000/confirm/",
+                ProductionConfirmationBase = "https://pegasus.se/confirm/",
+                DriverPortalUrl = "https://driver.pegasus.se"
+            }
+        });
+
+        var bookingRulesSettings = Options.Create(new BookingRulesSettings
+        {
+            MinHoursBeforePickupForChange = 2
+        });
+
+        var paginationSettings = Options.Create(new PaginationSettings
+        {
+            DefaultPageSize = 10,
+            MaxPageSize = 100
+        });
+
+        var recalculateHelper = new RecalculateIfAddressChangedHelper(mockValidationService.Object);
+        var validateUpdateRuleHelper = new ValidateUpdateRuleHelper(
+            mockValidationService.Object,
+            bookingRulesSettings.Value
+        );
+
+        var bookingDto = new CreateBookingDto
+        {
+            Email = "user@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567",
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            PickUpAddress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAddress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            Flightnumber = "SK123"
+        };
+
+        var testUser = new User
+        {
+            Id = "user123",
+            Email = "user@example.com",
+            UserName = "user@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567"
+        };
+
+        var validationResult = new ValidationResult
+        {
+            IsValid = true,
+            RouteInfo = new RouteInfoDto
+            {
+                DistanceKm = 42.5m,
+                DurationMinutes = 35,
+                Sections = new List<RouteSectionDto>()
+            },
+            CalculatedPrice = 450.00m
+        };
+
+        var booking = new Bookings
+        {
+            BookingId = 1,
+            UserIdFk = "user123",
+            Price = 450.00m,
+            BookingDateTime = DateTime.UtcNow,
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            PickUpAdress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAdress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            Status = BookingStatus.Confirmed,
+            IsConfirmed = true,
+            IsAvailable = true,
+            DistanceKm = 42.5m,
+            DurationMinutes = 35
+        };
+
+        var responseDto = new BookingResponseDto
+        {
+            BookingId = 1,
+            Email = "user@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567",
+            IsGuestBooking = false,
+            Price = 450.00m,
+            Status = BookingStatus.Confirmed,
+            PickUpAddress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAddress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            DistanceKm = 42.5m,
+            DurationMinutes = 35,
+            BookingDateTime = DateTime.UtcNow,
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            IsConfirmed = true
+        };
+
+        var mockDrivers = new List<Drivers>
+        {
+            new Drivers
+            {
+                DriverId = Guid.NewGuid(),
+                UserId = "driver1-user-id",
+                User = new User
+                {
+                    Id = "driver1-user-id",
+                    Email = "driver1@pegasus.se",
+                    UserName = "driver1@pegasus.se",
+                    FirstName = "Erik",
+                    LastName = "Andersson"
+                },
+                ProfilePicture = "https://example.com/erik.jpg",
+                IsDeleted = false
+            },
+            new Drivers
+            {
+                DriverId = Guid.NewGuid(),
+                UserId = "driver2-user-id",
+                User = new User
+                {
+                    Id = "driver2-user-id",
+                    Email = "driver2@pegasus.se",
+                    UserName = "driver2@pegasus.se",
+                    FirstName = "Anna",
+                    LastName = "Svensson"
+                },
+                ProfilePicture = "https://example.com/anna.jpg",
+                IsDeleted = false
+            }
+        };
+
+        mockValidationService
+            .Setup(x => x.ValidateBookingAsync(It.IsAny<CreateBookingDto>()))
+            .ReturnsAsync(validationResult);
+
+        mockUserManager
+            .Setup(x => x.FindByEmailAsync(bookingDto.Email))
+            .ReturnsAsync(testUser);
+
+        mockBookingFactory
+            .Setup(x => x.CreateBookingEntity(
+                It.IsAny<CreateBookingDto>(),
+                It.IsAny<RouteInfoDto>(),
+                It.IsAny<decimal>(),
+                It.IsAny<User?>(),
+                false))
+            .Returns(booking);
+
+        mockBookingRepo
+            .Setup(x => x.CreateBookingAsync(It.IsAny<Bookings>()))
+            .ReturnsAsync(booking);
+
+        mockMailjetService
+            .Setup(x => x.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<Helpers.MailjetHelpers.MailjetTemplateType>(),
+                It.IsAny<object>(),
+                It.IsAny<string>()))
+            .ReturnsAsync(ServiceResponse<bool>.SuccessResponse(HttpStatusCode.OK, true, "Email sent"));
+
+        mockDriverRepo
+            .Setup(x => x.GetAllDriversAsync())
+            .ReturnsAsync(mockDrivers);
+
+        mockBookingMapper
+            .Setup(x => x.MapToResponseDTO(It.IsAny<Bookings>()))
+            .Returns(responseDto);
+
+        mockEnv
+            .Setup(x => x.EnvironmentName)
+            .Returns("Development");
+
+        var bookingService = new BookingService(
+            mockBookingRepo.Object,
+            mockUserManager.Object,
+            mockMailjetService.Object,
+            mockValidationService.Object,
+            mockBookingFactory.Object,
+            mockBookingMapper.Object,
+            mockLogger.Object,
+            mailJetSettings,
+            bookingRulesSettings,
+            mockEnv.Object,
+            mockUserService.Object,
+            mockHttpContextAccessor.Object,
+            paginationSettings,
+            recalculateHelper,
+            validateUpdateRuleHelper,
+            mockMapService.Object,
+            mockDriverRepo.Object
+        );
+
+        // Act
+        var result = await bookingService.CreateBookingAsync(bookingDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.NotNull(result.Data);
+        Assert.False(result.Data.IsGuestBooking);
+        Assert.Equal(BookingStatus.Confirmed, result.Data.Status);
+        Assert.Contains("confirmed successfully", result.Message);
+
+        mockBookingRepo.Verify(
+            x => x.CreateBookingAsync(It.IsAny<Bookings>()),
+            Times.Once());
+
+        mockMailjetService.Verify(
+            x => x.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<Helpers.MailjetHelpers.MailjetTemplateType>(),
+                It.IsAny<object>(),
+                It.IsAny<string>()),
+            Times.Exactly(3));
+
+        mockDriverRepo.Verify(
+            x => x.GetAllDriversAsync(),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_ValidationFails_ReturnsError()
+    {
+        // Arrange
+        var mockBookingRepo = new Mock<IBookingRepo>();
+        var mockUserManager = new Mock<UserManager<User>>(
+            new Mock<IUserStore<User>>().Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!
+        );
+        var mockMailjetService = new Mock<IMailjetEmailService>();
+        var mockValidationService = new Mock<IBookingValidationService>();
+        var mockBookingFactory = new Mock<IBookingFactoryService>();
+        var mockBookingMapper = new Mock<IBookingMapperService>();
+        var mockLogger = new Mock<ILogger<BookingService>>();
+        var mockEnv = new Mock<IWebHostEnvironment>();
+        var mockUserService = new Mock<IUserService>();
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var mockMapService = new Mock<IMapService>();
+        var mockDriverRepo = new Mock<IDriverRepo>();
+
+        var mailJetSettings = Options.Create(new MailJetSettings
+        {
+            Links = new MailjetLinks
+            {
+                LocalConfirmationBase = "http://localhost:5000/confirm/",
+                ProductionConfirmationBase = "https://pegasus.se/confirm/",
+                DriverPortalUrl = "https://driver.pegasus.se"
+            }
+        });
+
+        var bookingRulesSettings = Options.Create(new BookingRulesSettings
+        {
+            MinHoursBeforePickupForChange = 2
+        });
+
+        var paginationSettings = Options.Create(new PaginationSettings
+        {
+            DefaultPageSize = 10,
+            MaxPageSize = 100
+        });
+
+        var recalculateHelper = new RecalculateIfAddressChangedHelper(mockValidationService.Object);
+        var validateUpdateRuleHelper = new ValidateUpdateRuleHelper(
+            mockValidationService.Object,
+            bookingRulesSettings.Value
+        );
+
+        var bookingDto = new CreateBookingDto
+        {
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567",
+            PickUpDateTime = DateTime.UtcNow.AddHours(12),
+            PickUpAddress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAddress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            Flightnumber = "SK123"
+        };
+
+        var failedValidation = new ValidationResult
+        {
+            IsValid = false,
+            ErrorResponse = ServiceResponse<BookingResponseDto>.FailResponse(
+                HttpStatusCode.BadRequest,
+                "PickUpDateTime must be at least 24 hours from now.")
+        };
+
+        mockValidationService
+            .Setup(x => x.ValidateBookingAsync(It.IsAny<CreateBookingDto>()))
+            .ReturnsAsync(failedValidation);
+
+        var bookingService = new BookingService(
+            mockBookingRepo.Object,
+            mockUserManager.Object,
+            mockMailjetService.Object,
+            mockValidationService.Object,
+            mockBookingFactory.Object,
+            mockBookingMapper.Object,
+            mockLogger.Object,
+            mailJetSettings,
+            bookingRulesSettings,
+            mockEnv.Object,
+            mockUserService.Object,
+            mockHttpContextAccessor.Object,
+            paginationSettings,
+            recalculateHelper,
+            validateUpdateRuleHelper,
+            mockMapService.Object,
+            mockDriverRepo.Object
+        );
+
+        // Act
+        var result = await bookingService.CreateBookingAsync(bookingDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.Contains("24 hours", result.Message);
+
+        mockUserManager.Verify(
+            x => x.FindByEmailAsync(It.IsAny<string>()),
+            Times.Never());
+
+        mockBookingRepo.Verify(
+            x => x.CreateBookingAsync(It.IsAny<Bookings>()),
+            Times.Never());
+
+        mockMailjetService.Verify(
+            x => x.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<Helpers.MailjetHelpers.MailjetTemplateType>(),
+                It.IsAny<object>(),
+                It.IsAny<string>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_ExceptionThrown_ReturnsInternalServerError()
+    {
+        // Arrange
+        var mockBookingRepo = new Mock<IBookingRepo>();
+        var mockUserManager = new Mock<UserManager<User>>(
+            new Mock<IUserStore<User>>().Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!
+        );
+        var mockMailjetService = new Mock<IMailjetEmailService>();
+        var mockValidationService = new Mock<IBookingValidationService>();
+        var mockBookingFactory = new Mock<IBookingFactoryService>();
+        var mockBookingMapper = new Mock<IBookingMapperService>();
+        var mockLogger = new Mock<ILogger<BookingService>>();
+        var mockEnv = new Mock<IWebHostEnvironment>();
+        var mockUserService = new Mock<IUserService>();
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var mockMapService = new Mock<IMapService>();
+        var mockDriverRepo = new Mock<IDriverRepo>();
+
+        var mailJetSettings = Options.Create(new MailJetSettings
+        {
+            Links = new MailjetLinks
+            {
+                LocalConfirmationBase = "http://localhost:5000/confirm/",
+                ProductionConfirmationBase = "https://pegasus.se/confirm/",
+                DriverPortalUrl = "https://driver.pegasus.se"
+            }
+        });
+
+        var bookingRulesSettings = Options.Create(new BookingRulesSettings
+        {
+            MinHoursBeforePickupForChange = 2
+        });
+
+        var paginationSettings = Options.Create(new PaginationSettings
+        {
+            DefaultPageSize = 10,
+            MaxPageSize = 100
+        });
+
+        var recalculateHelper = new RecalculateIfAddressChangedHelper(mockValidationService.Object);
+        var validateUpdateRuleHelper = new ValidateUpdateRuleHelper(
+            mockValidationService.Object,
+            bookingRulesSettings.Value
+        );
+
+        var bookingDto = new CreateBookingDto
+        {
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            PhoneNumber = "0701234567",
+            PickUpDateTime = DateTime.UtcNow.AddHours(48),
+            PickUpAddress = "Arlanda Airport",
+            PickUpLatitude = 59.6519,
+            PickUpLongitude = 17.9186,
+            DropOffAddress = "Stockholm Central",
+            DropOffLatitude = 59.3293,
+            DropOffLongitude = 18.0686,
+            Flightnumber = "SK123"
+        };
+
+        mockValidationService
+            .Setup(x => x.ValidateBookingAsync(It.IsAny<CreateBookingDto>()))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        var bookingService = new BookingService(
+            mockBookingRepo.Object,
+            mockUserManager.Object,
+            mockMailjetService.Object,
+            mockValidationService.Object,
+            mockBookingFactory.Object,
+            mockBookingMapper.Object,
+            mockLogger.Object,
+            mailJetSettings,
+            bookingRulesSettings,
+            mockEnv.Object,
+            mockUserService.Object,
+            mockHttpContextAccessor.Object,
+            paginationSettings,
+            recalculateHelper,
+            validateUpdateRuleHelper,
+            mockMapService.Object,
+            mockDriverRepo.Object
+        );
+
+        // Act
+        var result = await bookingService.CreateBookingAsync(bookingDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Contains("Something went wrong while creating booking", result.Message);
+    }
+}

--- a/PegasusBackend.Tests/Services/IdempotencyServiceTest.cs
+++ b/PegasusBackend.Tests/Services/IdempotencyServiceTest.cs
@@ -1,0 +1,341 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using PegasusBackend.Configurations;
+using PegasusBackend.Models;
+using PegasusBackend.Repositorys.Interfaces;
+using PegasusBackend.Services.Implementations;
+using System.Text.Json;
+
+namespace PegasusBackend.Tests.Services;
+
+public class IdempotencyServiceTest
+{
+    [Fact]
+    public async Task GetExistingRecordAsync_ReturnsRecord_WhenKeyExists()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 24,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        var testRecord = new IdempotencyRecord
+        {
+            IdempotencyKey = "test-key-123",
+            BookingId = 42,
+            ResponseData = "{\"bookingId\":42,\"status\":\"confirmed\"}",
+            StatusCode = 200,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(24)
+        };
+
+        mockRepo
+            .Setup(x => x.GetByKeyAsync(It.IsAny<string>()))
+            .ReturnsAsync(testRecord);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        // Act
+        var result = await service.GetExistingRecordAsync("test-key-123");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(testRecord.IdempotencyKey, result.IdempotencyKey);
+        Assert.Equal(testRecord.BookingId, result.BookingId);
+        Assert.Equal(testRecord.ResponseData, result.ResponseData);
+        Assert.Equal(testRecord.StatusCode, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetExistingRecordAsync_ReturnsNull_WhenKeyDoesNotExist()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 24,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        mockRepo
+            .Setup(x => x.GetByKeyAsync(It.IsAny<string>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        // Act
+        var result = await service.GetExistingRecordAsync("nonexistent-key");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateRecordAsync_CreatesRecord_WhenDataIsValid()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 24,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        var responseData = new
+        {
+            bookingId = 42,
+            status = "confirmed",
+            message = "Booking created successfully"
+        };
+
+        var createdRecord = new IdempotencyRecord
+        {
+            IdempotencyKey = "test-key-123",
+            BookingId = 42,
+            ResponseData = JsonSerializer.Serialize(responseData, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false
+            }),
+            StatusCode = 200,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(24)
+        };
+
+        mockRepo
+            .Setup(x => x.CreateAsync(It.IsAny<IdempotencyRecord>()))
+            .ReturnsAsync(createdRecord);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        // Act
+        var result = await service.CreateRecordAsync(
+            "test-key-123",
+            42,
+            responseData,
+            200
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("test-key-123", result.IdempotencyKey);
+        Assert.Equal(42, result.BookingId);
+        Assert.Equal(200, result.StatusCode);
+        Assert.Contains("\"bookingId\":42", result.ResponseData);
+
+        // Verify the record was created
+        mockRepo.Verify(
+            x => x.CreateAsync(It.Is<IdempotencyRecord>(r =>
+                r.IdempotencyKey == "test-key-123" &&
+                r.BookingId == 42 &&
+                r.StatusCode == 200
+            )),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateRecordAsync_SetsExpirationTime_BasedOnSettings()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 48,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        var beforeCreate = DateTime.UtcNow;
+
+        mockRepo
+            .Setup(x => x.CreateAsync(It.IsAny<IdempotencyRecord>()))
+            .ReturnsAsync((IdempotencyRecord record) => record);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        var responseData = new { bookingId = 42 };
+
+        // Act
+        await service.CreateRecordAsync(
+            "test-key",
+            42,
+            responseData,
+            200
+        );
+
+        var afterCreate = DateTime.UtcNow;
+
+        // Assert
+        mockRepo.Verify(
+            x => x.CreateAsync(It.Is<IdempotencyRecord>(r =>
+                r.ExpiresAt >= beforeCreate.AddHours(48).AddMinutes(-1) &&
+                r.ExpiresAt <= afterCreate.AddHours(48).AddMinutes(1)
+            )),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task CleanupExpiredRecordsAsync_ReturnsCount_WhenRecordsDeleted()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 24,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        mockRepo
+            .Setup(x => x.DeleteExpiredAsync())
+            .ReturnsAsync(5);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        // Act
+        var result = await service.CleanupExpiredRecordsAsync();
+
+        // Assert
+        Assert.Equal(5, result);
+
+        // Verify deletion was called
+        mockRepo.Verify(
+            x => x.DeleteExpiredAsync(),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task CleanupExpiredRecordsAsync_ReturnsZero_WhenNoRecordsToDelete()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 24,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        mockRepo
+            .Setup(x => x.DeleteExpiredAsync())
+            .ReturnsAsync(0);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        // Act
+        var result = await service.CleanupExpiredRecordsAsync();
+
+        // Assert
+        Assert.Equal(0, result);
+
+        // Verify deletion was called
+        mockRepo.Verify(
+            x => x.DeleteExpiredAsync(),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateRecordAsync_SerializesData_WithCamelCase()
+    {
+        // Arrange
+        var mockRepo = new Mock<IIdempotencyRepo>();
+        var mockLogger = new Mock<ILogger<IdempotencyService>>();
+        var mockSettings = new Mock<IOptions<IdempotencySettings>>();
+
+        var settings = new IdempotencySettings
+        {
+            ExpirationHours = 24,
+            CleanupIntervalHours = 6
+        };
+
+        mockSettings.Setup(x => x.Value).Returns(settings);
+
+        mockRepo
+            .Setup(x => x.CreateAsync(It.IsAny<IdempotencyRecord>()))
+            .ReturnsAsync((IdempotencyRecord record) => record);
+
+        var service = new IdempotencyService(
+            mockRepo.Object,
+            mockLogger.Object,
+            mockSettings.Object
+        );
+
+        var responseData = new
+        {
+            BookingId = 42,
+            CustomerName = "John Doe",
+            TotalPrice = 250.50
+        };
+
+        // Act
+        await service.CreateRecordAsync(
+            "test-key",
+            42,
+            responseData,
+            200
+        );
+
+        // Assert
+        mockRepo.Verify(
+            x => x.CreateAsync(It.Is<IdempotencyRecord>(r =>
+                r.ResponseData.Contains("\"bookingId\"") &&
+                r.ResponseData.Contains("\"customerName\"") &&
+                r.ResponseData.Contains("\"totalPrice\"")
+            )),
+            Times.Once());
+    }
+}


### PR DESCRIPTION
- Add 7 comprehensive unit tests for IdempotencyService
- Tests cover GetExistingRecordAsync, CreateRecordAsync, and CleanupExpiredRecordsAsync
- All tests follow existing project patterns from UserServiceTest
- All 20 tests passing